### PR TITLE
hard fail on v4 and soft-fail on v3 of the firmwares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=1.0.3
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/blue-merle
 	SECTION:=utils
 	CATEGORY:=Utilities
-	DEPENDS:=+bash +coreutils-shred +python3 +python3-pyserial +patch
+	DEPENDS:=gl-ui gl-e750-mcu +bash +coreutils-shred +python3 +python3-pyserial +patch
 	TITLE:=Anonymity Enhancements for GL-E750 Mudi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -102,7 +102,7 @@ define Package/blue-merle/preinst
 	            echo Version $$GL_VERSION is not supported
 	            exit 1
 	            ;;
-	        3.125)
+	        3.215)
 	            echo Version $$GL_VERSION is supported
 	            CHECK_MCUVERSION
 	            exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -144,8 +144,8 @@ define Package/blue-merle/postrm
 	mv /usr/bin/switchaction.orig /usr/bin/switchaction
 	mv /usr/bin/switch_queue.orig /usr/bin/switch_queue
 
-	rm /tmp/sim_change_start
-	rm /tmp/sim_change_switch
+	rm -f /tmp/sim_change_start
+	rm -f /tmp/sim_change_switch
 endef
 $(eval $(call BuildPackage,$(PKG_NAME)))
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -96,13 +96,27 @@ define Package/blue-merle/preinst
 		}
 
 	if grep -q "GL.iNet GL-E750" /proc/cpuinfo; then
-		if grep -q -w "3.215" /etc/glversion; then
-			CHECK_MCUVERSION
-			echo "Device is supported, installing blue-merle."
-			exit 0
-		else
-			ABORT_GLVERSION
-		fi
+	    GL_VERSION=$$(cat /etc/glversion)
+	    case $$GL_VERSION in
+	        4.*)
+	            echo Version $$GL_VERSION is not supported
+	            exit 1
+	            ;;
+	        3.125)
+	            echo Version $$GL_VERSION is supported
+	            CHECK_MCUVERSION
+	            exit 0
+	            ;;
+	        3.*)
+	            echo Version $$GL_VERSION is *probably* supported
+	            ABORT_GLVERSION
+	            ;;
+	        *)
+	            echo Unknown version $$GL_VERSION
+	            ABORT_GLVERSION
+	            ;;
+        esac
+        CHECK_MCUVERSION
 	else
 		ABORT_GLVERSION
 	fi


### PR DESCRIPTION
Now it automatically installs on 3.215 and fails on any v4. For other version 3 firmwares, the user is prompted.

I have tested these changes and they work.
[blue-merle_1.1.0-5_mips_24kc.ipk.gz](https://github.com/srlabs/blue-merle/files/12452649/blue-merle_1.1.0-5_mips_24kc.ipk.gz)
