### PR TITLE
mcu msg stage2 made more clear, add new + old IMEI shown in the end to visualy check + Firmware 4.3.9 check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=2.0.0
+PKG_VERSION:=2.0.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -44,7 +44,7 @@ define Package/blue-merle/preinst
 		if [ -f "/tmp/sysinfo/model" ] && [ -f "/etc/glversion" ]; then
 			echo "You have a `cat /tmp/sysinfo/model`, running firmware version `cat /etc/glversion`."
 		fi
-		echo "blue-merle has only been tested with GL-E750 Mudi Version 4.3.8."
+		echo "blue-merle has only been tested with GL-E750 Mudi Versions 4.3.8. and 4.3.9"
 		echo "The device or firmware version you are using have not been verified to work with blue-merle."
 		echo -n "Would you like to continue on your own risk? (y/N): "
 		read answer
@@ -67,7 +67,11 @@ define Package/blue-merle/preinst
 	            echo Version $$GL_VERSION is supported
 	            exit 0
 	            ;;
-	        4.*)
+	        4.3.9)
+	            echo Version $$GL_VERSION is supported
+	            exit 0
+	            ;;
+		4.*)
 	            echo Version $$GL_VERSION is *probably* supported
 	            ABORT_GLVERSION
 	            ;;

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -34,19 +34,24 @@ sleep 1
 new_imsi=$(READ_IMSI)
 
 if [[ "$old_imsi" == "$new_imsi" ]]; then
-	mcu_send_message "WARNING:        Old IMSI equals new IMSI."
+	mcu_send_message "WARNING:        Old IMSI equals new IMSI. Did you swap the SIM?"
 	sleep 3
 fi
-
+old_imei=$(READ_IMEI)
 mcu_send_message "Setting random   IMEI"
 timeout 15 python3 /lib/blue-merle/imei_generate.py -r
 
 new_imei=$(READ_IMEI)
 
+
 if [[ "$old_imei" == "$new_imei" ]]; then
 	mcu_send_message "WARNING:        Old IMEI equals new IMEI."
 	sleep 3
 else
+	#FIXME old_imei is not the real old imei because in stage1 its already generated a new one
+	# so this is a bit missleading but for the prupose of visualy see the change it works
+	mcu_send_message  "IMEI Old:...... ${old_imei}IMEI New:...... ${new_imei}"
+	sleep 5
 	mkdir -p /tmp/modem.1-1.2
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei
 fi


### PR DESCRIPTION
- To prevent miss reading IMSI/IMEI add question for SIM Change in the Warning message
- Fix check for IMEI change by reading in $old_imei again in stage2, maybe for the furture pass the old_imei from stage1
- show old and new imei in the end of the process to visualy see the change on the mcu fixes #21 