### PR TITLE
Fix: GH actions artifact actions deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir package-output
           rsync -av sdk/"${SDK_FILENAME%.tar.xz}"/bin/packages/mips_24kc/base/"${{ env.owrt-package }}"*.ipk package-output/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.generate-name.outputs.artifact-name }}
           path: package-output/


### PR DESCRIPTION
According to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ the artifact actions v3 which the ci.yml script uses will stop working on the 30th of January 2025. Because of this we should change the version to v4. In our use case there are no breaking changes. This will also get rid of the deprecation warning when running the actions.