### PR TITLE
fixes #62 imei leak via esim LPA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=blue-merle
-PKG_VERSION:=2.0.4
+PKG_VERSION:=2.0.5
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Matthias <matthias@srlabs.de>
@@ -44,7 +44,7 @@ define Package/blue-merle/preinst
 		if [ -f "/tmp/sysinfo/model" ] && [ -f "/etc/glversion" ]; then
 			echo "You have a `cat /tmp/sysinfo/model`, running firmware version `cat /etc/glversion`."
 		fi
-		echo "blue-merle has only been tested with GL-E750 Mudi Versions up to 4.3.19"
+		echo "blue-merle has only been tested with GL-E750 Mudi Versions up to 4.3.25"
 		echo "The device or firmware version you are using have not been verified to work with blue-merle."
 		echo -n "Would you like to continue on your own risk? (y/N): "
 		read answer
@@ -63,7 +63,7 @@ define Package/blue-merle/preinst
 	if grep -q "GL.iNet GL-E750" /proc/cpuinfo; then
 	    GL_VERSION=$$(cat /etc/glversion)
 	    case $$GL_VERSION in
-		4.3.19)
+		4.3.25)
 		    echo Version $$GL_VERSION is supported
 		    exit 0
 		    ;;

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ define Package/blue-merle/preinst
 		if [ -f "/tmp/sysinfo/model" ] && [ -f "/etc/glversion" ]; then
 			echo "You have a `cat /tmp/sysinfo/model`, running firmware version `cat /etc/glversion`."
 		fi
-		echo "blue-merle has only been tested with GL-E750 Mudi Versions up to 4.3.25"
+		echo "blue-merle has only been tested with GL-E750 Mudi Versions up to 4.3.26"
 		echo "The device or firmware version you are using have not been verified to work with blue-merle."
 		echo -n "Would you like to continue on your own risk? (y/N): "
 		read answer
@@ -63,7 +63,7 @@ define Package/blue-merle/preinst
 	if grep -q "GL.iNet GL-E750" /proc/cpuinfo; then
 	    GL_VERSION=$$(cat /etc/glversion)
 	    case $$GL_VERSION in
-		4.3.25)
+		4.3.26)
 		    echo Version $$GL_VERSION is supported
 		    exit 0
 		    ;;

--- a/files/usr/bin/blue-merle
+++ b/files/usr/bin/blue-merle
@@ -107,6 +107,9 @@ if [[ "$old_imei" == "$new_imei" ]]; then
 else
 	mkdir -p /tmp/modem.1-1.2
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei
+	# prevent imei leak via the LPA
+        echo "$new_imei" > /root/esim/imei
+        shred -u /root/esim/log.txt # unclear if the imei/imsi will be loged here, just a precaution
 fi
 
 echo "You should now reset the modem or shutdown the device."

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -54,6 +54,9 @@ else
 	sleep 5
 	mkdir -p /tmp/modem.1-1.2
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei
+	# prevent imei leak via the LPA
+	echo "$new_imei" > /root/esim/imei
+	shred -u /root/esim/log.txt # unclear if the imei/imsi will be loged here, just a precaution
 fi
 
 logger -p notice -t blue-merle-toggle "Changed IMEI from ${old_imei} to ${new_imei}"


### PR DESCRIPTION
- writes new imei into /root/esim/imei
- shreds and deltes /root/esim/log.txt
- mark firmware 4.3.25 as supported in the check

just tested manual on the device