### PR TITLE
Harden the IMEI-swap flow: forensic hygiene + rotation robustness + switch-abort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ define Package/blue-merle/postinst
 
 	/etc/init.d/gl_clients start
 
+	# Keep the IMEI record + LPA log in RAM only; shred/overwrite cannot erase them on UBIFS.
+	/etc/init.d/esim-volatile enable
+	/etc/init.d/esim-volatile start
+
 	echo {\"msg\": \"Successfully installed Blue Merle\"} > /dev/ttyS0
 endef
 

--- a/files/etc/gl-switch.d/sim.sh
+++ b/files/etc/gl-switch.d/sim.sh
@@ -5,26 +5,27 @@ logger -p notice -t blue-merle-toggle  "Called... ${action}"
 
 . /lib/functions/gl_util.sh
 
+mkdir -p /run/blue-merle && chmod 0700 /run/blue-merle
 
 
 if [ "$action" = "on" ];then
     mcu_send_message "Blue Merle ${action}"
-    echo "on" > /tmp/sim_change_switch
+    echo "on" > /run/blue-merle/sim_change_switch
     flock -n /tmp/blue-merle-switch.lock logger -p notice -t blue-merle-toggle "Running Stage 1" ||  logger -p notice -t blue-merle-toggle  "Lockfile busy"
     flock -n /tmp/blue-merle-switch.lock  timeout 90  /usr/bin/blue-merle-switch-stage1
 
 elif [ "$action" = "off" ];then
     # We check for any previous run and eventually execute the second stage. We could check for the age of this marker and only activate the second stage is the marker is young enough.
-    if [ -f /tmp/blue-merle-stage1 ]; then
+    if [ -f /run/blue-merle/stage1 ]; then
         flock -n /tmp/blue-merle-switch.lock  ||  logger -p notice -t blue-merle-toggle  "Lockfile busy" &
         flock -n /tmp/blue-merle-switch.lock  timeout 90  /usr/bin/blue-merle-switch-stage2
     else
         logger -p notice -t blue-merle-toggle  "No Stage 1; Toggling Off"
     fi
-    echo "off" > /tmp/sim_change_switch
+    echo "off" > /run/blue-merle/sim_change_switch
 
 else
-    echo "off" > /tmp/sim_change_switch
+    echo "off" > /run/blue-merle/sim_change_switch
 fi
 logger -p notice -t blue-merle-toggle  "Finished Switch $action"
 sleep 1

--- a/files/etc/init.d/esim-volatile
+++ b/files/etc/init.d/esim-volatile
@@ -1,0 +1,54 @@
+#!/bin/sh /etc/rc.common
+# esim-volatile — keep the IMEI record + LPA log in RAM, never on flash.
+#
+# blue-merle and the GL.iNet LPA write /root/esim/{imei,log.txt}, which land on
+# the UBIFS overlay (/dev/ubi0_1). UBIFS is log-structured: an in-place overwrite
+# (shred, or dd conv=notrunc) cannot erase the old block — it allocates a NEW one
+# and leaves the previous content recoverable until wear-levelling reclaims it.
+# Every IMEI swap therefore leaves a recoverable copy of the record on the NAND.
+#
+# Mounting /root/esim on tmpfs makes these writes RAM-only: nothing survives a
+# reboot and no IMEI/LPA-log residue ever reaches the flash. The eSIM PROFILE
+# store (db/) is the only part that must persist; it is kept on flash at $PERSIST
+# and bind-mounted back into the tmpfs, so eSIM profiles are preserved.
+#
+# Runs before blue-merle (START=10), the network stack, and any LPA activity.
+START=08
+STOP=99
+
+VOL=/root/esim
+PERSIST=/etc/blue-merle/esim-db
+
+_mounted() { mount 2>/dev/null | grep -q " on $VOL type tmpfs"; }
+
+start() {
+    _mounted && return 0
+    mkdir -p "$PERSIST" "$VOL"
+
+    # One-time migration: move any existing on-flash eSIM profile db into the
+    # persistent store (no-op on physical-SIM devices where db/ is empty).
+    if [ -d "$VOL/db" ] && [ ! -e "$PERSIST/.migrated" ]; then
+        cp -a "$VOL/db/." "$PERSIST/" 2>/dev/null
+        : > "$PERSIST/.migrated"
+    fi
+
+    # Preserve the non-sensitive LPA version tag to re-seed the tmpfs.
+    _ver=""
+    [ -f "$VOL/ver" ] && _ver=$(cat "$VOL/ver" 2>/dev/null)
+
+    mount -t tmpfs -o mode=0700,size=4M tmpfs "$VOL" || {
+        logger -p err -t esim-volatile "tmpfs mount FAILED — falling back to flash"
+        return 1
+    }
+    mkdir -p "$VOL/db"
+    mount --bind "$PERSIST" "$VOL/db" 2>/dev/null
+    [ -n "$_ver" ] && printf '%s' "$_ver" > "$VOL/ver"
+    logger -p notice -t esim-volatile "tmpfs mounted over $VOL (imei+log RAM-only; db persisted)"
+}
+
+boot() { start "$@"; }
+
+stop() {
+    umount "$VOL/db" 2>/dev/null
+    umount "$VOL" 2>/dev/null
+}

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -92,7 +92,10 @@ SET_IMEI() {
     local imei="$1"
 
     if [[ ${#imei} -eq 14 ]]; then
-        gl_modem AT AT+EGMR=1,7,${imei}
+        # The IMEI must be quoted, like imei_generate.py's set_imei() does
+        # (AT+EGMR=1,7,"<imei>"); without the quotes the EM060K rejects the
+        # write silently, so an unquoted restore would set nothing.
+        gl_modem AT AT+EGMR=1,7,\"${imei}\"
     else
         echo "IMEI is ${#imei} not 14 characters long"
     fi
@@ -153,12 +156,21 @@ SAFE_RESTORE_MODEM () {
         # Make sure the SIM is powered regardless of where we got interrupted.
         sim_switch on >/dev/null 2>&1
 
-        # If an EGMR write was started but never confirmed, restore the
-        # last known-good IMEI (kept in memory, never on disk) instead of
-        # leaving a half-written value.
+        # If an EGMR write was left unconfirmed, restore the last known-good IMEI
+        # (kept in memory, never on disk) instead of leaving a half-written value.
         if [ -f /run/blue-merle/imei_write_pending ]; then
                 if [ -n "$BM_KNOWN_GOOD_IMEI" ]; then
-                        SET_IMEI "$BM_KNOWN_GOOD_IMEI" >/dev/null 2>&1
+                        # EGMR writes are only accepted with the radio disabled,
+                        # so force CFUN=4 before restoring (sim_switch on above may
+                        # have re-enabled it); the CFUN=1 step below brings it back.
+                        gl_modem AT AT+CFUN=4 >/dev/null 2>&1
+                        # AT+EGMR=1,7 takes the 14-digit IMEI body and recomputes
+                        # the Luhn check digit itself; READ_IMEI returns the full
+                        # 15 digits, so write the first 14 (same body reproduces
+                        # the identical IMEI). Passing 15 would be rejected by
+                        # SET_IMEI's length check and silently restore nothing.
+                        restore_imei=$(printf '%s' "$BM_KNOWN_GOOD_IMEI" | cut -c1-14)
+                        SET_IMEI "$restore_imei" >/dev/null 2>&1
                 fi
                 rm -f /run/blue-merle/imei_write_pending
         fi

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -124,3 +124,58 @@ CHECK_ABORT () {
                 exit 1
         fi
 }
+
+# --- Recovery from an aborted or failed IMEI write (F-BRICK, CWE-364/665) ---
+#
+# Pulling the SIM/module, or an AT/EGMR write failing partway through,
+# can otherwise leave the modem wedged: SIM power off, radio disabled
+# (CFUN=4), and no confirmed IMEI. The two helpers below let a stage
+# remember the last known-good, already-confirmed IMEI before it attempts
+# to change it, and put the modem back into a known-good state (SIM
+# powered, radio enabled, previous IMEI restored if the new write was
+# never confirmed) whenever a stage aborts, fails, or exits unexpectedly.
+
+# Record the last confirmed-good IMEI on tmpfs only (/run/blue-merle is
+# root-only 0700, never written to flash or logged) so SAFE_RESTORE_MODEM
+# has something to roll back to.
+SAVE_KNOWN_GOOD_IMEI () {
+        local imei="$1"
+        if [ -n "$imei" ]; then
+                echo -n "$imei" > /run/blue-merle/imei_known_good
+        fi
+}
+
+# Bring the modem back to a known-good state. Safe to call more than once
+# and safe to call even if nothing was actually in progress.
+SAFE_RESTORE_MODEM () {
+        logger -p notice -t blue-merle-toggle "SAFE_RESTORE_MODEM: restoring modem state"
+
+        # Make sure the SIM is powered regardless of where we got interrupted.
+        sim_switch on >/dev/null 2>&1
+
+        # If an EGMR write was started but never confirmed, restore the
+        # last known-good IMEI instead of leaving a half-written value.
+        if [ -f /run/blue-merle/imei_write_pending ]; then
+                if [ -f /run/blue-merle/imei_known_good ]; then
+                        restore_imei=`cat /run/blue-merle/imei_known_good`
+                        if [ -n "$restore_imei" ]; then
+                                SET_IMEI "$restore_imei" >/dev/null 2>&1
+                        fi
+                fi
+                rm -f /run/blue-merle/imei_write_pending
+        fi
+
+        # Re-enable full functionality so the modem attaches again instead
+        # of being left disabled (CFUN=4).
+        restore_tries=3
+        while [ $restore_tries -gt 0 ]; do
+                gl_modem AT AT+CFUN=1 | grep -q OK && break
+                restore_tries=$((restore_tries-1))
+                sleep 1
+        done
+
+        # Don't let a stray reboot believe an interrupted stage1 completed.
+        rm -f /run/blue-merle/stage1
+
+        logger -p notice -t blue-merle-toggle "SAFE_RESTORE_MODEM: done"
+}

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -2,6 +2,10 @@
 
 # This script provides helper functions for blue-merle
 
+# Rotation control state lives in a root-only dir (0700), not world-writable /tmp
+# (CWE-377 / CWE-379).
+mkdir -p /run/blue-merle && chmod 0700 /run/blue-merle
+
 
 UNICAST_MAC_GEN () {
     loc_mac_numgen=`python3 -c "import random; print(f'{random.randint(0,2**48) & 0b111111101111111111111111111111111111111111111111:0x}'.zfill(12))"`
@@ -95,7 +99,7 @@ SET_IMEI() {
 }
 
 CHECK_ABORT () {
-        sim_change_switch=`cat /tmp/sim_change_switch`
+        sim_change_switch=`cat /run/blue-merle/sim_change_switch`
         if [[ "$sim_change_switch" = "off" ]]; then
                 echo '{ "msg": "SIM change      aborted." }' > /dev/ttyS0
                 sleep 1

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -135,14 +135,14 @@ CHECK_ABORT () {
 # powered, radio enabled, previous IMEI restored if the new write was
 # never confirmed) whenever a stage aborts, fails, or exits unexpectedly.
 
-# Record the last confirmed-good IMEI on tmpfs only (/run/blue-merle is
-# root-only 0700, never written to flash or logged) so SAFE_RESTORE_MODEM
-# has something to roll back to.
+# Record the last confirmed-good IMEI in a shell variable only (process
+# memory) -- never write the identifier to the filesystem. /run/blue-merle is
+# on the root overlay (UBIFS/flash) on this hardware, not tmpfs, and rm cannot
+# securely erase there, so a file would leave a recoverable IMEI on flash.
+# SAFE_RESTORE_MODEM always runs in the same shell (guard or EXIT trap), so an
+# in-memory value is enough to roll back to.
 SAVE_KNOWN_GOOD_IMEI () {
-        local imei="$1"
-        if [ -n "$imei" ]; then
-                echo -n "$imei" > /run/blue-merle/imei_known_good
-        fi
+        BM_KNOWN_GOOD_IMEI="$1"
 }
 
 # Bring the modem back to a known-good state. Safe to call more than once
@@ -154,21 +154,14 @@ SAFE_RESTORE_MODEM () {
         sim_switch on >/dev/null 2>&1
 
         # If an EGMR write was started but never confirmed, restore the
-        # last known-good IMEI instead of leaving a half-written value.
+        # last known-good IMEI (kept in memory, never on disk) instead of
+        # leaving a half-written value.
         if [ -f /run/blue-merle/imei_write_pending ]; then
-                if [ -f /run/blue-merle/imei_known_good ]; then
-                        restore_imei=`cat /run/blue-merle/imei_known_good`
-                        if [ -n "$restore_imei" ]; then
-                                SET_IMEI "$restore_imei" >/dev/null 2>&1
-                        fi
+                if [ -n "$BM_KNOWN_GOOD_IMEI" ]; then
+                        SET_IMEI "$BM_KNOWN_GOOD_IMEI" >/dev/null 2>&1
                 fi
                 rm -f /run/blue-merle/imei_write_pending
         fi
-
-        # The known-good IMEI has served its purpose here; don't leave the
-        # identifier sitting in a file (tmpfs/root-only, but still forensic
-        # hygiene -- consistent with the rest of the package).
-        rm -f /run/blue-merle/imei_known_good
 
         # Re-enable full functionality so the modem attaches again instead
         # of being left disabled (CFUN=4).

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -165,6 +165,11 @@ SAFE_RESTORE_MODEM () {
                 rm -f /run/blue-merle/imei_write_pending
         fi
 
+        # The known-good IMEI has served its purpose here; don't leave the
+        # identifier sitting in a file (tmpfs/root-only, but still forensic
+        # hygiene -- consistent with the rest of the package).
+        rm -f /run/blue-merle/imei_known_good
+
         # Re-enable full functionality so the modem attaches again instead
         # of being left disabled (CFUN=4).
         restore_tries=3

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -104,7 +104,9 @@ SET_IMEI() {
 CHECK_ABORT () {
         sim_change_switch=`cat /run/blue-merle/sim_change_switch`
         if [[ "$sim_change_switch" = "off" ]]; then
-                echo '{ "msg": "SIM change      aborted." }' > /dev/ttyS0
+                echo '{ "msg": "SIM change      aborted.        Original restored." }' > /dev/ttyS0
+                logger -p notice -t blue-merle-toggle "switch off during stage1; aborting swap cleanly"
+                SAFE_RESTORE_MODEM
                 sleep 1
                 exit 1
         fi
@@ -120,12 +122,63 @@ CHECK_ABORT () {
         # destructive step.
         if [ -f /run/blue-merle/abort_requested ]; then
                 rm -f /run/blue-merle/abort_requested
-                echo '{ "msg": "SIM change      aborted." }' > /dev/ttyS0
+                echo '{ "msg": "SIM change      aborted.        Original restored." }' > /dev/ttyS0
                 logger -p notice -t blue-merle-toggle "abort_requested set; aborting swap cleanly"
                 SAFE_RESTORE_MODEM
                 sleep 1
                 exit 1
         fi
+}
+
+# True if the physical mode switch is currently in the OFF position, read
+# directly from the kernel. The GL-E750 wires the slider to gpio-1 (label
+# "switch", ACTIVE LOW): held ON reads "lo", released to OFF reads "hi". Reading
+# the level directly works even while the OFF button-handler is blocked behind
+# stage1's gl-switch lock -- which is why upstream ("we cannot notice the pulled
+# switch") could not implement this.
+#
+# Source: /sys/kernel/debug/gpio. On this platform that is the only userspace
+# read of the *current* level: the line is owned by the gpio-button-hotplug
+# driver, which (unlike mainline gpio-keys) creates no /dev/input device to
+# query, and a claimed line cannot be requested via sysfs or the gpio cdev. If a
+# more stable source is available on a given build (e.g. a gpio-keys input
+# device, or libgpiod against an unclaimed line) this one function is where to
+# swap it in. debugfs is mounted by default on the GL firmware; we make sure,
+# and degrade safely (return non-OFF -> never abort a swap spuriously) if the
+# state still can't be read.
+SWITCH_OFF () {
+        _gp=/sys/kernel/debug/gpio
+        [ -r "$_gp" ] || mount -t debugfs none /sys/kernel/debug 2>/dev/null
+        [ -r "$_gp" ] || return 1
+        _sw=$(grep "|switch" "$_gp" 2>/dev/null | grep -oE " (hi|lo) " | tr -d " ")
+        [ "$_sw" = "hi" ]
+}
+
+# stage1-only abort check: abort if the user pulled the physical switch back to
+# OFF before the SIM-swap handoff, or if a flag-based abort was requested. Must
+# NOT be used in stage2, where the switch is OFF by definition (that is what
+# starts stage2) -- there CHECK_ABORT (flag only) is the right check.
+CHECK_STAGE1_ABORT () {
+        if SWITCH_OFF; then
+                echo '{ "msg": "SIM change      aborted.        Original restored." }' > /dev/ttyS0
+                logger -p notice -t blue-merle-toggle "switch pulled back to OFF during stage1; aborting cleanly"
+                SAFE_RESTORE_MODEM
+                sleep 1
+                exit 1
+        fi
+        CHECK_ABORT
+}
+
+# Sleep up to $1 seconds, but check for an abort (switch pulled or flag) every
+# second so a switch pulled during stage1 is noticed promptly instead of only at
+# the next fixed checkpoint. stage1-only (uses CHECK_STAGE1_ABORT).
+ABORT_SLEEP () {
+        _n="$1"
+        while [ "$_n" -gt 0 ]; do
+                CHECK_STAGE1_ABORT
+                sleep 1
+                _n=$((_n-1))
+        done
 }
 
 # --- Recovery from an aborted or failed IMEI write (F-BRICK, CWE-364/665) ---
@@ -156,9 +209,12 @@ SAFE_RESTORE_MODEM () {
         # Make sure the SIM is powered regardless of where we got interrupted.
         sim_switch on >/dev/null 2>&1
 
-        # If an EGMR write was left unconfirmed, restore the last known-good IMEI
-        # (kept in memory, never on disk) instead of leaving a half-written value.
-        if [ -f /run/blue-merle/imei_write_pending ]; then
+        # Restore the last known-good IMEI (kept in memory, never on disk) if
+        # either an EGMR write was left unconfirmed (imei_write_pending) or the
+        # user aborted stage1 after it had already written its throwaway
+        # temporary IMEI (restore_original). In both cases we want the ORIGINAL
+        # identity back, not a half-written or temporary value.
+        if [ -f /run/blue-merle/imei_write_pending ] || [ -f /run/blue-merle/restore_original ]; then
                 if [ -n "$BM_KNOWN_GOOD_IMEI" ]; then
                         # EGMR writes are only accepted with the radio disabled,
                         # so force CFUN=4 before restoring (sim_switch on above may
@@ -172,7 +228,7 @@ SAFE_RESTORE_MODEM () {
                         restore_imei=$(printf '%s' "$BM_KNOWN_GOOD_IMEI" | cut -c1-14)
                         SET_IMEI "$restore_imei" >/dev/null 2>&1
                 fi
-                rm -f /run/blue-merle/imei_write_pending
+                rm -f /run/blue-merle/imei_write_pending /run/blue-merle/restore_original
         fi
 
         # Re-enable full functionality so the modem attaches again instead
@@ -184,8 +240,9 @@ SAFE_RESTORE_MODEM () {
                 sleep 1
         done
 
-        # Don't let a stray reboot believe an interrupted stage1 completed.
-        rm -f /run/blue-merle/stage1
+        # Don't let a stray reboot believe an interrupted stage1 completed, and
+        # clear the abort marker so nothing leaks into the next run.
+        rm -f /run/blue-merle/stage1 /run/blue-merle/abort_requested
 
         logger -p notice -t blue-merle-toggle "SAFE_RESTORE_MODEM: done"
 }

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -105,4 +105,22 @@ CHECK_ABORT () {
                 sleep 1
                 exit 1
         fi
+
+        # Generic, switch-independent abort request (F-BRICK / CWE-364/665).
+        # The check above only fires while stage1 is running with the
+        # physical switch already flipped back to "off" -- during stage2 the
+        # switch is already "off" by definition (that is what started it), so
+        # it can never signal an abort there. A caller (or a future UI) can
+        # instead `touch /run/blue-merle/abort_requested` at any time; every
+        # CHECK_ABORT call site in either stage will notice it at the next
+        # safe checkpoint, restore the modem, and stop before the next
+        # destructive step.
+        if [ -f /run/blue-merle/abort_requested ]; then
+                rm -f /run/blue-merle/abort_requested
+                echo '{ "msg": "SIM change      aborted." }' > /dev/ttyS0
+                logger -p notice -t blue-merle-toggle "abort_requested set; aborting swap cleanly"
+                SAFE_RESTORE_MODEM
+                sleep 1
+                exit 1
+        fi
 }

--- a/files/usr/bin/blue-merle
+++ b/files/usr/bin/blue-merle
@@ -109,7 +109,8 @@ else
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei
 	# prevent imei leak via the LPA
         echo "$new_imei" > /root/esim/imei
-        shred -u /root/esim/log.txt # unclear if the imei/imsi will be loged here, just a precaution
+        # /root/esim is a tmpfs (see /etc/init.d/esim-volatile) so the log never reaches flash.
+        rm -f /root/esim/log.txt
 fi
 
 echo "You should now reset the modem or shutdown the device."

--- a/files/usr/bin/blue-merle-switch-stage1
+++ b/files/usr/bin/blue-merle-switch-stage1
@@ -15,7 +15,10 @@ now=$(date +%s)
 sim_change_last=`cat /run/blue-merle/sim_change_start`
 sim_change_diff=$((now-sim_change_last))
 
-if [[ "$sim_change_diff" -lt 60  ]]; then
+# F-CLOCK (CWE-754): only rate-limit on a sane, non-negative delta. If the clock
+# jumped backwards (RTC reset / before NTP sync) now-stored can go negative, which
+# would otherwise wedge the "please wait" guard and block every swap indefinitely.
+if [ "$sim_change_diff" -ge 0 ] && [ "$sim_change_diff" -lt 60 ]; then
 	mcu_send_message "Please wait     >1min between   two SIM swaps.  ($sim_change_diff s)"
 	exit 1
 fi

--- a/files/usr/bin/blue-merle-switch-stage1
+++ b/files/usr/bin/blue-merle-switch-stage1
@@ -25,6 +25,20 @@ echo "$now" > /run/blue-merle/sim_change_start
 mcu_send_message "Starting SIM    swap."
 sleep 3
 
+# From here on we may leave the modem disabled / mid-write if we are
+# interrupted (SIM/module pulled, power loss, killed process). Restore the
+# modem on any unexpected exit unless we reach the end of this stage, where
+# leaving the radio disabled is the intended handoff to the physical SIM
+# swap (F-BRICK, CWE-364/665).
+stage1_committed=0
+STAGE1_TRAP_CLEANUP () {
+	if [ "$stage1_committed" != "1" ]; then
+		logger -p notice -t blue-merle-toggle "stage1 exited early; running SAFE_RESTORE_MODEM"
+		SAFE_RESTORE_MODEM
+	fi
+}
+trap STAGE1_TRAP_CLEANUP EXIT INT TERM HUP
+
 
 ## We're disabling this abort functionality for the moment because the switch keeps being blocked and we cannot notice the pulled switch. We could abort by default and require another toggle to continue.
 #i=5
@@ -45,6 +59,7 @@ sleep 3
 
 old_imei=$(READ_IMEI)
 old_imsi=$(READ_IMSI)
+SAVE_KNOWN_GOOD_IMEI "$old_imei"
 
 #CHECK_ABORT
 
@@ -64,10 +79,27 @@ done
 ## We generate a random IMEI to prevent a leak of the
 ## new SIM's IMSI under the old IMEI in case the modem
 ## still talks to the network
+CHECK_ABORT
+echo 1 > /run/blue-merle/imei_write_pending
 timeout 15  python3 /lib/blue-merle/imei_generate.py -r
+temp_imei_rc=$?
+
+if [ "$temp_imei_rc" -ne 0 ]; then
+	mcu_send_message "WARNING:        Temp IMEI write failed. Restoring."
+	logger -p notice -t blue-merle-toggle "stage1 temp IMEI write failed (rc=$temp_imei_rc)"
+	# stage1_committed is still 0 here, so STAGE1_TRAP_CLEANUP runs
+	# SAFE_RESTORE_MODEM for us on the way out.
+	exit 1
+fi
+rm -f /run/blue-merle/imei_write_pending
 
 
 mcu_send_message "Replace the SIM card. Then pull the switch."
+
+# Past this point the radio is intentionally left disabled awaiting the
+# physical SIM swap + stage2 -- that is success, not a wedged modem, so the
+# trap above must no longer call SAFE_RESTORE_MODEM.
+stage1_committed=1
 
 echo done > /run/blue-merle/stage1
 logger -p notice -t blue-merle-toggle "Finished with Stage 1"

--- a/files/usr/bin/blue-merle-switch-stage1
+++ b/files/usr/bin/blue-merle-switch-stage1
@@ -3,16 +3,16 @@
 . /lib/blue-merle/functions.sh
 . /lib/functions/gl_util.sh
 
-if [ ! -f "/tmp/sim_change_start" ]; then
-	echo 0 > /tmp/sim_change_start
+if [ ! -f "/run/blue-merle/sim_change_start" ]; then
+	echo 0 > /run/blue-merle/sim_change_start
 fi
 
-if [ ! -f "/tmp/sim_change_switch" ]; then
+if [ ! -f "/run/blue-merle/sim_change_switch" ]; then
 	sim_switch off
 fi
 
 now=$(date +%s)
-sim_change_last=`cat /tmp/sim_change_start`
+sim_change_last=`cat /run/blue-merle/sim_change_start`
 sim_change_diff=$((now-sim_change_last))
 
 if [[ "$sim_change_diff" -lt 60  ]]; then
@@ -20,7 +20,7 @@ if [[ "$sim_change_diff" -lt 60  ]]; then
 	exit 1
 fi
 
-echo "$now" > /tmp/sim_change_start
+echo "$now" > /run/blue-merle/sim_change_start
 
 mcu_send_message "Starting SIM    swap."
 sleep 3
@@ -69,5 +69,5 @@ timeout 15  python3 /lib/blue-merle/imei_generate.py -r
 
 mcu_send_message "Replace the SIM card. Then pull the switch."
 
-echo done > /tmp/blue-merle-stage1
+echo done > /run/blue-merle/stage1
 logger -p notice -t blue-merle-toggle "Finished with Stage 1"

--- a/files/usr/bin/blue-merle-switch-stage1
+++ b/files/usr/bin/blue-merle-switch-stage1
@@ -25,8 +25,11 @@ fi
 
 echo "$now" > /run/blue-merle/sim_change_start
 
+# Clear any stale abort-window marker from a previously crashed run.
+rm -f /run/blue-merle/restore_original
+
 mcu_send_message "Starting SIM    swap."
-sleep 3
+ABORT_SLEEP 3
 
 # From here on we may leave the modem disabled / mid-write if we are
 # interrupted (SIM/module pulled, power loss, killed process). Restore the
@@ -58,20 +61,25 @@ trap STAGE1_TRAP_CLEANUP EXIT INT TERM HUP
 #sleep 1
 
 mcu_send_message "Disabling the ME from transmitting and receiving RF signals."
-sleep 3
+ABORT_SLEEP 3
 
 old_imei=$(READ_IMEI)
 old_imsi=$(READ_IMSI)
 SAVE_KNOWN_GOOD_IMEI "$old_imei"
 
-#CHECK_ABORT
+# The original IMEI is now saved. If the user aborts from here on -- even after
+# the throwaway temporary IMEI is written below -- SAFE_RESTORE_MODEM must put
+# the ORIGINAL identity back, not leave the temporary one. This marker tells it to.
+echo 1 > /run/blue-merle/restore_original
+
+CHECK_STAGE1_ABORT
 
 answer=1
 while [[ "$answer" -eq 1 ]]; do
 	gl_modem AT AT+CFUN=4 | grep -q OK
 	if [[ $? -eq 1 ]]; then
 		mcu_send_message "Disabling failed. Trying again."
-		CHECK_ABORT
+		CHECK_STAGE1_ABORT
 	else
 		answer=0
 		mcu_send_message "Disabled."
@@ -82,7 +90,7 @@ done
 ## We generate a random IMEI to prevent a leak of the
 ## new SIM's IMSI under the old IMEI in case the modem
 ## still talks to the network
-CHECK_ABORT
+CHECK_STAGE1_ABORT
 echo 1 > /run/blue-merle/imei_write_pending
 timeout 15  python3 /lib/blue-merle/imei_generate.py -r
 temp_imei_rc=$?
@@ -96,13 +104,19 @@ if [ "$temp_imei_rc" -ne 0 ]; then
 fi
 rm -f /run/blue-merle/imei_write_pending
 
+# Last abort window: the temporary IMEI is written but we have NOT yet asked the
+# user to swap the SIM, so a switch-off here still means "abort" -> restore the
+# original identity. After the message below, a switch-off means "continue".
+CHECK_STAGE1_ABORT
 
 mcu_send_message "Replace the SIM card. Then pull the switch."
 
 # Past this point the radio is intentionally left disabled awaiting the
 # physical SIM swap + stage2 -- that is success, not a wedged modem, so the
-# trap above must no longer call SAFE_RESTORE_MODEM.
+# trap above must no longer call SAFE_RESTORE_MODEM. A switch-off now means
+# "SIM swapped, continue to stage2", so drop the abort-window markers.
 stage1_committed=1
+rm -f /run/blue-merle/restore_original /run/blue-merle/abort_requested
 
 echo done > /run/blue-merle/stage1
 logger -p notice -t blue-merle-toggle "Finished with Stage 1"

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -50,7 +50,7 @@ if [[ "$old_imei" == "$new_imei" ]]; then
 else
 	#FIXME old_imei is not the real old imei because in stage1 its already generated a new one
 	# so this is a bit missleading but for the prupose of visualy see the change it works
-	mcu_send_message  "IMEI Old:...... ${old_imei}IMEI New:...... ${new_imei}"
+	mcu_send_message  "IMEI rotated.   New IMEI active."
 	sleep 5
 	mkdir -p /tmp/modem.1-1.2
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -5,6 +5,20 @@
 
 rm -f /run/blue-merle/stage1
 
+# From here on the modem may be left disabled or mid-EGMR-write if we are
+# interrupted (SIM/module pulled again, power loss, killed process). Restore
+# it on any unexpected exit; stage2_committed is set once the rotation (or a
+# clean fallback) has actually completed, so a normal successful run does
+# not re-touch the modem right before poweroff (F-BRICK, CWE-364/665).
+stage2_committed=0
+STAGE2_TRAP_CLEANUP () {
+	if [ "$stage2_committed" != "1" ]; then
+		logger -p notice -t blue-merle-toggle "stage2 exited early; running SAFE_RESTORE_MODEM"
+		SAFE_RESTORE_MODEM
+	fi
+}
+trap STAGE2_TRAP_CLEANUP EXIT INT TERM HUP
+
 mcu_send_message "Switch pulled.  Continuing..."
 sleep 1
 sim_switch on
@@ -29,6 +43,11 @@ if [[ $leak -eq 1 ]]; then
 	sleep 3
 fi
 
+# Safe checkpoint: radio is confirmed re-enabled (CFUN=4) and nothing
+# destructive has happened yet on this side of the swap, so an abort here
+# is cheap -- SAFE_RESTORE_MODEM just needs to bring CFUN back to 1.
+CHECK_ABORT
+
 sleep 1
 
 new_imsi=$(READ_IMSI)
@@ -38,11 +57,29 @@ if [[ "$old_imsi" == "$new_imsi" ]]; then
 	sleep 3
 fi
 old_imei=$(READ_IMEI)
+SAVE_KNOWN_GOOD_IMEI "$old_imei"
 mcu_send_message "Setting random   IMEI"
+echo 1 > /run/blue-merle/imei_write_pending
 timeout 15 python3 /lib/blue-merle/imei_generate.py -r
+imei_write_rc=$?
 
 new_imei=$(READ_IMEI)
 
+# Guard the EGMR write (F-BRICK, CWE-364/665): only trust it if the helper
+# reported success AND a re-read actually returned an IMEI. Otherwise we may
+# have a half-written IMEI -- restore the last known-good one and bring the
+# radio back up instead of silently continuing as if nothing happened.
+imei_write_ok=1
+if [ "$imei_write_rc" -ne 0 ] || [ -z "$new_imei" ]; then
+	imei_write_ok=0
+	mcu_send_message "WARNING:        IMEI write      failed. Restoring."
+	logger -p notice -t blue-merle-toggle "EGMR write failed (rc=$imei_write_rc); running SAFE_RESTORE_MODEM"
+	SAFE_RESTORE_MODEM
+	sleep 3
+fi
+
+if [ "$imei_write_ok" -eq 1 ]; then
+	rm -f /run/blue-merle/imei_write_pending
 
 if [[ "$old_imei" == "$new_imei" ]]; then
 	mcu_send_message "WARNING:        Old IMEI equals new IMEI."
@@ -59,6 +96,13 @@ else
 	# /root/esim is a tmpfs (see /etc/init.d/esim-volatile) so the log never reaches flash.
 	rm -f /root/esim/log.txt
 fi
+
+fi
+
+# Whatever path above ran, the modem is now in a known state (rotated,
+# unchanged-but-fine, or restored) -- past this point the trap no longer
+# needs to call SAFE_RESTORE_MODEM.
+stage2_committed=1
 
 logger -p notice -t blue-merle-toggle "IMEI rotated"
 

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -3,7 +3,7 @@
 . /lib/blue-merle/functions.sh
 . /lib/functions/gl_util.sh
 
-rm -f /tmp/blue-merle-stage1
+rm -f /run/blue-merle/stage1
 
 mcu_send_message "Switch pulled.  Continuing..."
 sleep 1

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -56,7 +56,8 @@ else
 	echo "$new_imei" > /tmp/modem.1-1.2/modem-imei
 	# prevent imei leak via the LPA
 	echo "$new_imei" > /root/esim/imei
-	shred -u /root/esim/log.txt # unclear if the imei/imsi will be loged here, just a precaution
+	# /root/esim is a tmpfs (see /etc/init.d/esim-volatile) so the log never reaches flash.
+	rm -f /root/esim/log.txt
 fi
 
 logger -p notice -t blue-merle-toggle "IMEI rotated"

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -59,7 +59,7 @@ else
 	shred -u /root/esim/log.txt # unclear if the imei/imsi will be loged here, just a precaution
 fi
 
-logger -p notice -t blue-merle-toggle "Changed IMEI from ${old_imei} to ${new_imei}"
+logger -p notice -t blue-merle-toggle "IMEI rotated"
 
 
 mcu_send_message "The device will shutdown now."

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -104,12 +104,6 @@ fi
 # needs to call SAFE_RESTORE_MODEM.
 stage2_committed=1
 
-# Drop the known-good IMEI now that the rotation is committed -- no reason to
-# keep the identifier lying around in /run until the next reboot (forensic
-# hygiene, consistent with PR-A). SAFE_RESTORE_MODEM does the same on the
-# abort/failure paths that never reach this point.
-rm -f /run/blue-merle/imei_known_good
-
 logger -p notice -t blue-merle-toggle "IMEI rotated"
 
 

--- a/files/usr/bin/blue-merle-switch-stage2
+++ b/files/usr/bin/blue-merle-switch-stage2
@@ -104,6 +104,12 @@ fi
 # needs to call SAFE_RESTORE_MODEM.
 stage2_committed=1
 
+# Drop the known-good IMEI now that the rotation is committed -- no reason to
+# keep the identifier lying around in /run until the next reboot (forensic
+# hygiene, consistent with PR-A). SAFE_RESTORE_MODEM does the same on the
+# abort/failure paths that never reach this point.
+rm -f /run/blue-merle/imei_known_good
+
 logger -p notice -t blue-merle-toggle "IMEI rotated"
 
 

--- a/files/usr/bin/sim_switch
+++ b/files/usr/bin/sim_switch
@@ -1,7 +1,8 @@
+mkdir -p /run/blue-merle && chmod 0700 /run/blue-merle
 if [ "$1" = "on" ];then
-	echo "on" > /tmp/sim_change_switch
+	echo "on" > /run/blue-merle/sim_change_switch
 elif [ "$1" = "off" ];then
-	echo "off" > /tmp/sim_change_switch
+	echo "off" > /run/blue-merle/sim_change_switch
 else
-	echo "off" > /tmp/sim_change_switch
+	echo "off" > /run/blue-merle/sim_change_switch
 fi

--- a/files/usr/libexec/blue-merle
+++ b/files/usr/libexec/blue-merle
@@ -3,9 +3,16 @@
 . /lib/blue-merle/functions.sh
 
 
+_mcu_json_escape() {
+    # Escape backslash and double-quote so text (e.g. modem output) can't break
+    # out of the JSON string sent to the MCU. (CWE-116 / CWE-74)
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 show_message() {
     # There is mcu_send_message() in /lib/functions/gl_util.sh but we don't want to load the file, thinking that it will take too long
-    echo {\"msg\": \"$1\"} > /dev/ttyS0
+    msg=$(_mcu_json_escape "$1")
+    echo {\"msg\": \"$msg\"} > /dev/ttyS0
 }
 
 

--- a/files/usr/share/rpcd/acl.d/luci-app-blue-merle.json
+++ b/files/usr/share/rpcd/acl.d/luci-app-blue-merle.json
@@ -1,12 +1,11 @@
 {
 	"luci-app-blue-merle": {
-		"description": "Grant access to opkg management",
+		"description": "Grant access to blue-merle IMEI/IMSI controls",
 		"read": {
 			"cgi-io": [ "exec" ],
 			"file": {
-				"/usr/libexec/blue-merle": [ "exec" ],
-				"/usr/libexec/blue-merle shred": [ "exec" ],
-				"/usr/libexec/blue-merle *": [ "exec" ],
+				"/usr/libexec/blue-merle read-imei": [ "exec" ],
+				"/usr/libexec/blue-merle read-imsi": [ "exec" ],
 				"/etc/opkg.conf": [ "read" ],
 				"/etc/opkg/*.conf": [ "read" ]
 			},
@@ -16,10 +15,9 @@
 		},
 		"write": {
 			"file": {
-				"/usr/libexec/blue-merle": [ "exec" ],
-				"/usr/libexec/blue-merle shred": [ "exec" ],
-				"/usr/libexec/blue-merle *": [ "exec" ],
-				"/tmp/upload.ipk": [ "write" ]
+				"/usr/libexec/blue-merle random-imei": [ "exec" ],
+				"/usr/libexec/blue-merle shutdown-modem": [ "exec" ],
+				"/usr/libexec/blue-merle shutdown": [ "exec" ]
 			}
 		}
 	}


### PR DESCRIPTION
This hardens blue-merle's IMEI-swap flow in three related ways, all touching the
same swap-flow scripts so they ship as one bundle rather than PRs that would
collide on the same files:

1. **Forensic hygiene** — stop the flow leaking/persisting the IMEI it's meant to hide.
2. **Rotation robustness** — an interrupted swap can't leave the modem wedged.
3. **Switch-abort** — pulling the slider back before the SIM-swap prompt cleanly
   aborts and restores the original IMEI (a thing upstream had given up on).

Tested on a GL-E750 (Mudi v2) / EM060K-GL on GL.iNet firmware 4.3.26: script
checks plus on-device swap/abort behaviour, and an on-air check against a private
srsRAN + Open5GS cell (details in Test setup). `sh -n` passes on all changed
scripts; the ACL is valid JSON. Off the swap path there is no behaviour change;
the abort is a new user capability.

## Part 1 — Forensic hygiene: don't leak/persist/expose the IMEI

An IMEI anonymizer shouldn't leak the IMEI itself. blue-merle currently writes the
cleartext IMEI to syslog and to the OLED during a swap, leaves recoverable copies
on flash (shred doesn't erase on UBIFS), and keeps its rotation state
world-writable in /tmp. Six small fixes, one commit each:

- `acl`: drop the libexec wildcard and the shred / upload.ipk grants
- `stage2`: don't show the cleartext IMEI on the OLED during a swap
- `stage2`: stop logging the cleartext IMEI to syslog
- `libexec`: escape the MCU JSON string
- `state`: move rotation state to a root-only dir (`/run/blue-merle`), not world-writable `/tmp`
- `esim`: keep the IMEI/LPA log on tmpfs instead of shredding it (shred can't erase UBIFS)

**Why tmpfs instead of shred:** the E750 overlay is UBIFS (log-structured NAND). An
in-place overwrite writes a new block and leaves the old one recoverable. Imaging
the raw NAND of a stock device after 4 swaps recovered 5 distinct IMEIs from flash,
including the original — shred had "cleaned" the log but the content was still
there. Mounting /root/esim on tmpfs keeps those writes in RAM; the eSIM profile DB
is bind-mounted back from flash so eSIM users aren't affected.

## Part 2 — Rotation robustness: an interrupted swap can't brick the modem

The swap hands off across a physical action (the user swaps the SIM) between two
root scripts that each toggle the modem's radio and, in stage2, write a new IMEI
over AT (`AT+EGMR`). Neither has a user-triggerable abort mid-stage2, nor any
recovery if a stage is interrupted — SIM pulled early, the E750's thermal cutoff,
or the process killed mid-write. The modem is left however the interrupted sequence
left it: radio possibly still off (`CFUN=4`), IMEI possibly half-written. That's a
wedged AT/QMI state, worst-case needing a manual reset or reflash.

Eight small commits — seven robustness commits, plus one fix to the restore
helper they rely on (last item):

- `functions`: a switch-independent `abort_requested` flag in `CHECK_ABORT`
- `functions`: `SAVE_KNOWN_GOOD_IMEI` + `SAFE_RESTORE_MODEM` recovery helpers
- `stage1`: guard the temp-IMEI write + trap-based cleanup
- `stage2`: guard the EGMR write + trap-based cleanup
- `stage1`: don't wedge the swap rate-limiter on a backwards clock jump
- `functions,stage2`: drop the known-good IMEI after use
- `functions,stage2`: keep the known-good IMEI in memory, never on flash
- `functions`: fix `SET_IMEI` so the known-good restore actually writes (quote the
  `AT+EGMR` arg, 14-digit body, `CFUN=4`)

Restore targets the **last EGMR-confirmed IMEI**, not the factory-original (that
would need EFS/NV backup handling — out of scope for a brick guard).

`SAFE_RESTORE_MODEM` writes the saved IMEI back through blue-merle's existing
`SET_IMEI` helper. That helper had latent bugs that made the write a silent no-op
— it emitted `AT+EGMR` **unquoted** (the EM060K only accepts the quoted form), fed
it the 15-digit IMEI where `EGMR` takes the 14-digit body, and could run with the
radio already re-enabled. `SET_IMEI` had effectively no live callers upstream, so
this only surfaced once `SAFE_RESTORE_MODEM` relied on it — and only under hardware
testing (earlier comparisons matched trivially because the IMEI had never actually
changed). One commit in this bundle fixes `SET_IMEI` (quote the arg, use the
14-digit body, force `CFUN=4`) so the restore here actually restores.

## Part 3 — Switch-abort: pull the switch back to cancel a swap

Upstream disabled the switch-as-abort control on purpose — the code comment says
*"the switch keeps being blocked and we cannot notice the pulled switch."* The
reason: `/etc/rc.button/switch` runs the handlers under a blocking flock on
`/var/lock/gl-switch.lock`, and `sim.sh on` holds that lock for stage1's whole
duration, so the OFF handler can't run until stage1 has already finished.

This makes the switch an abort control again by **reading the slider position
directly from the GPIO** at each stage1 checkpoint (`gpio-1`, label `switch`,
ACTIVE LOW), which the blocked handler can't affect. Pulling the switch back to
OFF *before* the "Replace SIM card" prompt aborts the swap and restores the
**original** IMEI; after that prompt a pull means "continue to stage2" as before.

One commit (it depends on the Part 2 `SET_IMEI` restore fix above):

- stage1 reads the slider position via `SWITCH_OFF` at each checkpoint, through the
  stage1-only `CHECK_STAGE1_ABORT`; `ABORT_SLEEP` polls it during the pre-swap
  sleeps. (stage2 keeps the flag-only `CHECK_ABORT` — its switch is OFF by
  definition.)
- a `restore_original` marker is set once the original IMEI is saved, so an abort
  *after* the temporary IMEI was written still restores the original —
  `SAFE_RESTORE_MODEM` honours it.
- `sim.sh` is unchanged: the GPIO read is what notices the pull, so the blocked OFF
  handler is irrelevant.

On the read source: `/sys/kernel/debug/gpio` is a debug interface, but on this
platform it's the only userspace read of the current level — `/sys/class/gpio`
export returns EBUSY (the line is claimed by `gpio-button-hotplug`, which also
exposes no `/dev/input`), and libgpiod against a claimed line is refused. It fails
safe (never aborts spuriously) and is a one-function choke point — happy to switch
to a cleaner source a maintainer prefers on their target.

## Test setup

- **Device under test:** GL-E750 (Mudi v2), EM060K-GL modem, GL.iNet firmware
  4.3.26, factory-clean install of this build.
- **Private LTE cell:** a bladeRF 2.0 micro xA9 SDR running open5Gcube (srsRAN eNB
  + Open5GS EPC), LTE band 8, 6 PRB, on the reserved **test PLMN 999/70** with a
  sysmoISIM test SIM. Conducted RF (u.FL pigtail), isolated lab network — no public
  spectrum.
- **Method:** script checks (`sh -n`, ACL JSON validity) and the modem / GPIO / swap
  behaviour below were exercised on the device over SSH. On-device checks compare
  identifiers for equality rather than printing them; the on-air validation is run
  in the isolated lab, where the full test-SIM identifiers are captured as local
  evidence. This public writeup reports the conclusions, not the captured values.

## Tested (hardware)

GL-E750 (Mudi v2) / EM060K-GL on GL.iNet firmware 4.3.26, factory-clean install of
this build. Identifiers are handled per the lab's evidence practice; captured
values are kept local and omitted from this writeup.

- Part 1: before/after swaps show no cleartext IMEI in syslog or on the OLED;
  rotation state lands in `/run/blue-merle` at mode 0700; the eSIM log stays on
  tmpfs; raw-NAND re-image after a swap shows no new residue.
- Part 2, abort: `touch /run/blue-merle/abort_requested` → `CHECK_ABORT` exits 1,
  consumes the flag, modem stays `CFUN=1`.
- Part 2, interrupted EGMR: modem forced to the wedged `CFUN=4` +
  `imei_write_pending` state → `SAFE_RESTORE_MODEM` brought it back to `CFUN=1` and
  cleared the pending flag. (The IMEI *restore-to-known-good* itself is proven
  separately and deterministically — see the restore-fix bullet below; the
  `SET_IMEI` helper it relies on had to be fixed before the write did anything.)
- Part 2, traps: a stage2-style victim killed mid-run (synchronous `exit 1` and an
  external `kill -TERM`) ran `SAFE_RESTORE_MODEM` and left the modem `CFUN=1`.
- Part 2, **real physical interrupt**: on the actual GL slider switch, flipping ON
  then straight back to OFF killed the running stage1 with SIGTERM *mid AT+EGMR
  write* (`rc=143`); the write-failure guard + EXIT trap recovered the modem to
  `CFUN=1` with a valid IMEI, `/run` clean, no poweroff. (Also: with the abort flag
  pre-armed, the same switch flip aborted at the checkpoint — both `CHECK_ABORT` and
  the trap ran `SAFE_RESTORE_MODEM`, which is idempotent.)
- Part 2, F-CLOCK: a future-dated `sim_change_start` (backwards clock) was allowed,
  a <60 s timestamp rate-limited, a >60 s timestamp allowed.
- Part 3, switch-abort (physical switch): flipping ON then back to OFF during
  "Disabling the ME" logged `switch pulled back to OFF during stage1; aborting
  cleanly`, ran `SAFE_RESTORE_MODEM`, and left `CFUN=1` with the **original IMEI
  restored** (equality check, value withheld), `/run` clean, no poweroff.
- Restore fix (Part 2): verified deterministically by genuinely changing the IMEI
  and restoring it (previously a silent no-op — earlier "match" results were
  trivial because the IMEI had never actually changed).
- Part 3, regression: a full normal swap (switch held ON through stage1 → "Replace
  SIM card" → OFF) still rotates and powers off — the GPIO checks don't false-abort
  a legitimate swap.
- **On-air (end-to-end sanity):** S1AP/NAS captured on the private cell during a
  full LTE attach. The MME requests the IMEISV (`Security mode command`,
  `imeisv_req=1`) and the modem returns it in `Security mode complete`. The IMEISV
  the network sees matches the (spoofed) IMEI the modem currently holds — the
  network sees exactly the presented identity, with no stale or factory IMEI
  appearing. This confirms the forensic-hygiene changes didn't break blue-merle's
  existing on-air anonymization (the on-air spoofing itself is unchanged by this
  PR). The lab uses null ciphering (EEA0) so the IMEISV is readable; a real network
  ciphers it. Capture kept local.
- `sh -n` passes on all changed scripts; no new package dependencies.

## Notes

- The spoofed IMEI is still in the GL firmware's modem cache (/tmp/... in RAM) so
  the admin UI keeps showing it — the spoofed value, not a real-IMEI leak.
- `volatile-client-macs` is handled separately in #73 (shred → tmpfs for the
  client-MAC DB).
