### PR TITLE
MAC/BSSID vendor mimicry: opt-in, coherent-by-default, LuCI toggle (supersedes #74)

### DIFF
--- a/files/etc/blue-merle/oui-vendors
+++ b/files/etc/blue-merle/oui-vendors
@@ -1,0 +1,50 @@
+# blue-merle MAC mimicry OUI table
+#
+# Used when mac.mimic is enabled (see /etc/config/blue-merle). Instead of a
+# purely random locally-administered MAC, blue-merle draws a real vendor OUI
+# from this list and appends 3 random bytes, so the address looks like ordinary
+# consumer hardware rather than an obviously-randomized one.
+#
+# Format:  <vendor>  <OUI>  <type>
+#   type = ap      -> used for the router BSSID (RESET_BSSIDS)
+#   type = client  -> used for the client-facing / upstream MAC (RANDOMIZE_MACADDR)
+#
+# These are public IEEE OUI assignments, given as examples. Add or remove rows
+# to fit where you travel — e.g. keep only vendors common in your region so the
+# device blends in. Lines starting with # and blank lines are ignored.
+#
+# Note: this only changes the OUI. The radio's advertised capabilities and
+# beacon fingerprint still come from the chipset/driver, so prefer vendors that
+# shipped hardware of the same Wi-Fi generation (and ideally chipset family) as
+# your device. See the "Limitations" note in the docs.
+#
+# Use only full MA-L (/24) OUIs. MA-M and MA-S prefixes share their first three
+# octets among 16 or 4096 companies, so a random tail on such a prefix lands in a
+# different company's block. Most web OUI lookups won't tell you a prefix is
+# shared; when in doubt, check the IEEE registry.
+# Restrict which vendors are used from the LuCI page or via
+#   uci set blue-merle.mac.ap_vendors='tp-link,netgear'
+
+# --- routers / access points (BSSID) ---
+tp-link   50:C7:BF   ap
+tp-link   EC:08:6B   ap
+netgear   20:4E:7F   ap
+netgear   A0:40:A0   ap
+asus      2C:56:DC   ap
+asus      AC:22:0B   ap
+cisco     6C:03:B5   ap
+linksys   00:14:BF   ap
+dlink     1C:BD:B9   ap
+avm       3C:A6:2F   ap
+
+# --- phones / client devices (client MAC) ---
+apple     00:1B:63   client
+apple     AC:BC:32   client
+samsung   00:16:6C   client
+samsung   38:8A:06   client
+xiaomi    64:CC:2E   client
+huawei    48:46:FB   client
+google    3C:5A:B4   client
+intel     34:13:E8   client
+intel     00:1B:21   client
+oneplus   C0:EE:FB   client

--- a/files/etc/config/blue-merle
+++ b/files/etc/config/blue-merle
@@ -1,0 +1,15 @@
+
+config mac 'mac'
+	# Master switch for vendor-mimicking MAC/BSSID randomization.
+	# Off by default: no behaviour change unless you opt in.
+	option mimic '0'
+	# coherent = one vendor OUI, sequential across every interface (like real
+	# single-vendor hardware); split = independent router/client vendor OUIs.
+	option mode 'coherent'
+	# When the GL firmware provides its own MAC randomization (newer versions),
+	# skip ours to avoid randomizing twice / fighting the stock feature.
+	option auto_disable_native '1'
+	# Comma-separated vendor filter, empty = use all vendors from the OUI table.
+	# e.g. ap_vendors='tp-link,netgear'  client_vendors='apple,samsung'
+	option ap_vendors ''
+	option client_vendors ''

--- a/files/lib/blue-merle/functions.sh
+++ b/files/lib/blue-merle/functions.sh
@@ -3,16 +3,90 @@
 # This script provides helper functions for blue-merle
 
 
+BM_OUI_TABLE=/etc/blue-merle/oui-vendors
+
 UNICAST_MAC_GEN () {
     loc_mac_numgen=`python3 -c "import random; print(f'{random.randint(0,2**48) & 0b111111101111111111111111111111111111111111111111:0x}'.zfill(12))"`
     loc_mac_formatted=$(echo "$loc_mac_numgen" | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\)\(..\).*$/\1:\2:\3:\4:\5:\6/')
     echo "$loc_mac_formatted"
 }
 
+# True when the GL firmware ships its own MAC randomization and the user asked
+# us to defer to it (mac.auto_disable_native). The exact uci key differs between
+# GL firmware versions, so we probe a few and can be extended as new ones appear.
+# 4.3.26 has none of these, so this returns false there.
+GL_NATIVE_MAC_RANDOM_ACTIVE () {
+    [ "$(uci -q get blue-merle.mac.auto_disable_native)" = "1" ] || return 1
+    for key in glconfig.general.mac_random glconfig.general.macrandom \
+               glconfig.general.random_mac network.@device[1].random_mac; do
+        v=$(uci -q get "$key")
+        [ -n "$v" ] && [ "$v" != "0" ] && [ "$v" != "off" ] && return 0
+    done
+    return 1
+}
+
+# Master toggle: vendor mimicry on AND not deferring to a native feature.
+MAC_MIMIC_ENABLED () {
+    [ "$(uci -q get blue-merle.mac.mimic)" = "1" ] || return 1
+    GL_NATIVE_MAC_RANDOM_ACTIVE && return 1
+    return 0
+}
+
+# coherent (default): every interface derives from one base MAC with a
+# sequential last octet, the way real single-vendor hardware lays out its
+# interfaces (eth0 ..:63, wlan0 ..:64, wlan1 ..:65). split: router and client
+# roles get independent vendor OUIs. BM_MAC_BASE holds the shared base for the
+# current apply run.
+BM_MAC_BASE=""
+
+MAC_MODE () {
+    [ "$(uci -q get blue-merle.mac.mode)" = "split" ] && echo split || echo coherent
+}
+
+# Generate the shared base once per apply (router-vendor OUI + random NIC).
+# Empty in split mode / when disabled, so GEN_MAC falls back to per-role OUIs.
+MAC_BASE_INIT () {
+    if MAC_MIMIC_ENABLED && [ "$(MAC_MODE)" = "coherent" ]; then
+        BM_MAC_BASE=$(python3 /lib/blue-merle/mac_mimic.py ap "$(uci -q get blue-merle.mac.ap_vendors)" "$BM_OUI_TABLE")
+    else
+        BM_MAC_BASE=""
+    fi
+}
+
+# GEN_MAC <role> <offset>
+# coherent -> base + offset (one OUI, sequential); split -> per-role vendor OUI;
+# disabled -> the original random unicast address.
+GEN_MAC () {
+    local role="$1" offset="${2:-0}" vendors=""
+    if MAC_MIMIC_ENABLED; then
+        if [ -n "$BM_MAC_BASE" ]; then
+            python3 /lib/blue-merle/mac_mimic.py derive "$BM_MAC_BASE" "$offset" && return 0
+        else
+            case "$role" in
+                ap)     vendors=$(uci -q get blue-merle.mac.ap_vendors) ;;
+                client) vendors=$(uci -q get blue-merle.mac.client_vendors) ;;
+            esac
+            python3 /lib/blue-merle/mac_mimic.py "$role" "$vendors" "$BM_OUI_TABLE" && return 0
+        fi
+    fi
+    UNICAST_MAC_GEN
+}
+
+# List the distinct vendors available for a role ("ap"|"client"), comma-joined.
+# Pure awk (no sort/paste) so it works on busybox.
+MAC_LIST_VENDORS () {
+    awk -v kind="$1" '
+        /^[ \t]*#/ { next }
+        NF>=3 && $3==kind && !seen[$1]++ { out = out sep $1; sep="," }
+        END { print out }
+    ' "$BM_OUI_TABLE"
+}
+
 # randomize BSSID
 RESET_BSSIDS () {
-    uci set wireless.@wifi-iface[1].macaddr=`UNICAST_MAC_GEN`
-    uci set wireless.@wifi-iface[0].macaddr=`UNICAST_MAC_GEN`
+    MAC_BASE_INIT
+    uci set wireless.@wifi-iface[0].macaddr=`GEN_MAC ap 0`
+    uci set wireless.@wifi-iface[1].macaddr=`GEN_MAC ap 1`
     uci commit wireless
     # you need to reset wifi for changes to apply, i.e. executing "wifi"
 }
@@ -21,9 +95,12 @@ RESET_BSSIDS () {
 RANDOMIZE_MACADDR () {
     # This changes the MAC address clients see when connecting to the WiFi spawned by the device.
     # You can check with "arp -a" that your endpoint, e.g. your laptop, sees a different MAC after a reboot of the Mudi.
-    uci set network.@device[1].macaddr=`UNICAST_MAC_GEN`
+    # In coherent mode this shares the base set up by RESET_BSSIDS in the same
+    # run; if we're called standalone, seed one first.
+    [ -z "$BM_MAC_BASE" ] && MAC_BASE_INIT
+    uci set network.@device[1].macaddr=`GEN_MAC client 2`
     # Here we change the MAC address the upstream wifi sees
-    uci set glconfig.general.macclone_addr=`UNICAST_MAC_GEN`
+    uci set glconfig.general.macclone_addr=`GEN_MAC client 3`
     uci commit network
     # You need to restart the network, i.e. /etc/init.d/network restart
 }

--- a/files/lib/blue-merle/mac_mimic.py
+++ b/files/lib/blue-merle/mac_mimic.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Generate a vendor-mimicking MAC address for blue-merle.
+
+Reads the OUI table (default /etc/blue-merle/oui-vendors), picks a real vendor
+OUI of the requested type, and appends three random bytes. The vendor OUI is
+kept as-is (globally-administered), so the result looks like ordinary consumer
+hardware instead of an obviously locally-administered random address.
+
+Usage:
+    mac_mimic.py <ap|client> [vendor_csv] [oui_file]
+
+If no OUI matches the request, it falls back to a locally-administered random
+MAC so callers always get a usable address.
+"""
+import random
+import sys
+
+
+def load_ouis(path, kind, want):
+    wanted = {v.strip().lower() for v in want.split(",") if v.strip()} if want else None
+    ouis = []
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                vendor, oui, typ = parts[0].lower(), parts[1], parts[2].lower()
+                if typ != kind:
+                    continue
+                if wanted is not None and vendor not in wanted:
+                    continue
+                ouis.append(oui)
+    except OSError:
+        pass
+    return ouis
+
+
+def random_laa():
+    # Locally-administered, unicast: set bit 1, clear bit 0 of the first octet.
+    first = (random.randint(0, 255) & 0b11111100) | 0b00000010
+    rest = [random.randint(0, 255) for _ in range(5)]
+    return ":".join("%02x" % b for b in [first] + rest)
+
+
+def derive(base, offset):
+    # Return base with its last octet shifted by offset (mod 256), keeping the
+    # OUI intact — the way real hardware numbers its interfaces (..63/..64/..65).
+    parts = base.split(":")
+    if len(parts) != 6:
+        return base
+    parts[-1] = "%02x" % ((int(parts[-1], 16) + offset) & 0xFF)
+    return ":".join(p.lower() for p in parts)
+
+
+def main():
+    if len(sys.argv) >= 2 and sys.argv[1] == "derive":
+        if len(sys.argv) < 4:
+            sys.stderr.write("usage: mac_mimic.py derive <base_mac> <offset>\n")
+            return 2
+        print(derive(sys.argv[2], int(sys.argv[3])))
+        return 0
+    if len(sys.argv) < 2 or sys.argv[1] not in ("ap", "client"):
+        sys.stderr.write("usage: mac_mimic.py <ap|client> [vendor_csv] [oui_file] | derive <base> <offset>\n")
+        return 2
+    kind = sys.argv[1]
+    want = sys.argv[2] if len(sys.argv) > 2 else ""
+    path = sys.argv[3] if len(sys.argv) > 3 else "/etc/blue-merle/oui-vendors"
+
+    ouis = load_ouis(path, kind, want)
+    if not ouis:
+        # No matching vendor OUI -> fall back to a random locally-administered MAC.
+        print(random_laa())
+        return 0
+
+    oui = random.choice(ouis).lower()
+    tail = ":".join("%02x" % random.randint(0, 255) for _ in range(3))
+    print("%s:%s" % (oui, tail))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/usr/libexec/blue-merle
+++ b/files/usr/libexec/blue-merle
@@ -42,6 +42,45 @@ elif [ "$1" == "shutdown" ]; then
 elif [ "$1" == "write-imei" ]; then
     new_imei=$2
     echo -n  { "action": "write" }
+
+elif [ "$1" == "mac-status" ]; then
+    echo "mimic=$(uci -q get blue-merle.mac.mimic)"
+    echo "mode=$(MAC_MODE)"
+    if GL_NATIVE_MAC_RANDOM_ACTIVE; then echo "native=1"; else echo "native=0"; fi
+    echo "ap_vendors=$(uci -q get blue-merle.mac.ap_vendors)"
+    echo "client_vendors=$(uci -q get blue-merle.mac.client_vendors)"
+    echo "ap_all=$(MAC_LIST_VENDORS ap)"
+    echo "client_all=$(MAC_LIST_VENDORS client)"
+
+elif [ "$1" == "mac-on" ]; then
+    uci set blue-merle.mac.mimic='1'; uci commit blue-merle; echo -n "1"
+
+elif [ "$1" == "mac-off" ]; then
+    uci set blue-merle.mac.mimic='0'; uci commit blue-merle; echo -n "0"
+
+elif [ "$1" == "mac-set-ap" ]; then
+    uci set blue-merle.mac.ap_vendors="$2"; uci commit blue-merle; echo -n "$2"
+
+elif [ "$1" == "mac-set-client" ]; then
+    uci set blue-merle.mac.client_vendors="$2"; uci commit blue-merle; echo -n "$2"
+
+elif [ "$1" == "mac-set-mode" ]; then
+    uci set blue-merle.mac.mode="$2"; uci commit blue-merle; echo -n "$2"
+
+elif [ "$1" == "mac-preview" ]; then
+    # Show every interface's next MAC, without changing anything.
+    MAC_BASE_INIT
+    echo "wifi0(2.4G)=$(GEN_MAC ap 0)"
+    echo "wifi1(5G)=$(GEN_MAC ap 1)"
+    echo "wan=$(GEN_MAC client 2)"
+    echo "clone=$(GEN_MAC client 3)"
+
+elif [ "$1" == "mac-apply" ]; then
+    RESET_BSSIDS
+    RANDOMIZE_MACADDR
+    logger -p notice -t blue-merle-libexec "MAC mimicry applied (reload wifi/network to take effect)"
+    echo -n "applied"
+
 else
     echo -n   '{"msg":"Hello, World!"}'
     #echo 'foo'>&2

--- a/files/usr/share/rpcd/acl.d/luci-app-blue-merle.json
+++ b/files/usr/share/rpcd/acl.d/luci-app-blue-merle.json
@@ -7,6 +7,8 @@
 				"/usr/libexec/blue-merle": [ "exec" ],
 				"/usr/libexec/blue-merle shred": [ "exec" ],
 				"/usr/libexec/blue-merle *": [ "exec" ],
+				"/usr/libexec/blue-merle mac-status": [ "exec" ],
+				"/usr/libexec/blue-merle mac-preview": [ "exec" ],
 				"/etc/opkg.conf": [ "read" ],
 				"/etc/opkg/*.conf": [ "read" ]
 			},
@@ -19,6 +21,12 @@
 				"/usr/libexec/blue-merle": [ "exec" ],
 				"/usr/libexec/blue-merle shred": [ "exec" ],
 				"/usr/libexec/blue-merle *": [ "exec" ],
+				"/usr/libexec/blue-merle mac-on": [ "exec" ],
+				"/usr/libexec/blue-merle mac-off": [ "exec" ],
+				"/usr/libexec/blue-merle mac-set-ap *": [ "exec" ],
+				"/usr/libexec/blue-merle mac-set-client *": [ "exec" ],
+				"/usr/libexec/blue-merle mac-set-mode *": [ "exec" ],
+				"/usr/libexec/blue-merle mac-apply": [ "exec" ],
 				"/tmp/upload.ipk": [ "write" ]
 			}
 		}

--- a/files/www/luci-static/resources/view/blue-merle.js
+++ b/files/www/luci-static/resources/view/blue-merle.js
@@ -342,6 +342,144 @@ function handleUpload(ev)
 function handleInput(ev) {
 }
 
+
+/* ---- MAC / BSSID vendor-mimicry section ------------------------------- */
+
+function callBlueMerleArgs(args) {
+    const cmd = "/usr/libexec/blue-merle";
+    return fs.exec(cmd, args).then(function(res) {
+        if (res.code != 0)
+            throw new Error("Return code " + res.code);
+        return res.stdout || "";
+    });
+}
+
+function parseKV(text) {
+    var o = {};
+    (text || "").split("\n").forEach(function(line) {
+        var i = line.indexOf("=");
+        if (i > 0)
+            o[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+    });
+    return o;
+}
+
+function onVendorChange(role, wrap) {
+    var boxes = wrap.querySelectorAll('input[type=checkbox]');
+    var chosen = [], total = 0;
+    boxes.forEach(function(cb) { total++; if (cb.checked) chosen.push(cb.value); });
+    // All checked == no restriction, so store empty to keep the config clean.
+    var csv = (chosen.length === total) ? '' : chosen.join(',');
+    callBlueMerleArgs([role === 'ap' ? 'mac-set-ap' : 'mac-set-client', csv]);
+}
+
+function vendorCheckboxes(role, allCsv, selCsv) {
+    var all = (allCsv || "").split(",").filter(Boolean);
+    var sel = (selCsv || "").split(",").filter(Boolean);
+    var wrap = E('div', { 'style': 'display:flex;flex-wrap:wrap;gap:.6em;margin:.3em 0 .6em 0;' });
+    all.forEach(function(v) {
+        var cb = E('input', { 'type': 'checkbox', 'value': v });
+        // Empty selection means "all", so pre-check accordingly.
+        if (sel.length === 0 || sel.indexOf(v) >= 0)
+            cb.checked = true;
+        cb.addEventListener('change', function() { onVendorChange(role, wrap); });
+        wrap.appendChild(E('label', { 'style': 'white-space:nowrap;' }, [cb, ' ' + v]));
+    });
+    return wrap;
+}
+
+function macModeHelp(mode) {
+    if (mode === 'split')
+        return _('Split gives the hotspot (BSSID) and the client/WAN side different vendor OUIs. Coherent is the safer default; use split only if the Mudi runs as a pure Wi-Fi client and does not broadcast its own hotspot. Mixed-vendor OUIs on one device are not a reliable tell on their own — the stronger signal is the radio fingerprint (see the notes).');
+    return _('Coherent makes the whole device — both radios and the WAN — share one vendor OUI with sequential MACs, exactly like a real single-vendor router. Recommended for normal use (LTE uplink, or when the Mudi hosts a hotspot).');
+}
+
+function populateMacSection(container) {
+    return callBlueMerle('mac-status').then(function(text) {
+        var st = parseKV(text);
+        var enabled = st.mimic === '1';
+        var native = st.native === '1';
+        var mode = st.mode || 'coherent';
+        container.innerHTML = '';
+
+        var box = E('div', { 'style': 'border:1px solid rgba(128,128,128,.35);border-radius:6px;padding:.8em 1em;max-width:760px;' });
+        container.appendChild(box);
+
+        // 1) master enable
+        var toggle = E('input', { 'type': 'checkbox', 'id': 'mac-mimic-toggle', 'disabled': isReadonlyView });
+        toggle.checked = enabled;
+        toggle.addEventListener('change', function() {
+            // Only flip the setting — no rebuild, so the preview output survives.
+            callBlueMerle(toggle.checked ? 'mac-on' : 'mac-off');
+        });
+        box.appendChild(E('label', { 'style': 'font-weight:bold;font-size:1.05em;' },
+            [toggle, ' ' + _('Enable MAC / BSSID mimicry')]));
+        box.appendChild(E('p', { 'class': 'cbi-value-description' },
+            _('Off by default. When on, blue-merle draws a real vendor OUI from /etc/blue-merle/oui-vendors and appends random bytes, so the device blends in with ordinary consumer hardware instead of an obviously-randomized address.')));
+
+        if (native)
+            box.appendChild(E('p', { 'style': 'color:#c60;font-weight:bold;' },
+                _('The GL firmware provides its own MAC randomization; blue-merle is deferring to it (auto_disable_native).')));
+
+        box.appendChild(E('hr', { 'style': 'border:none;border-top:1px solid rgba(128,128,128,.25);margin:.7em 0;' }));
+
+        // 2) mode
+        var modeSel = E('select', { 'disabled': isReadonlyView }, [
+            E('option', { 'value': 'coherent' }, _('Coherent (recommended)')),
+            E('option', { 'value': 'split' }, _('Split (advanced — pure client only)'))
+        ]);
+        modeSel.value = mode;
+        modeSel.addEventListener('change', function() {
+            // Mode change swaps which vendor pickers apply, so rebuild the section.
+            callBlueMerleArgs(['mac-set-mode', modeSel.value]).then(function() {
+                populateMacSection(container);
+            });
+        });
+        box.appendChild(E('div', { 'style': 'margin:.2em 0;' }, [
+            E('label', { 'style': 'margin-right:.5em;font-weight:bold;' }, _('OUI mode') + ':'),
+            modeSel
+        ]));
+        box.appendChild(E('p', { 'class': 'cbi-value-description' }, macModeHelp(mode)));
+
+        // 3) vendor pickers — only what the current mode actually uses
+        if (mode === 'split') {
+            box.appendChild(E('h4', { 'style': 'margin-bottom:.2em;' }, _('Router / BSSID vendors')));
+            box.appendChild(E('p', { 'class': 'cbi-value-description' }, _('OUIs used for the hotspot the Mudi broadcasts.')));
+            box.appendChild(vendorCheckboxes('ap', st.ap_all, st.ap_vendors));
+            box.appendChild(E('h4', { 'style': 'margin-bottom:.2em;' }, _('Client / device vendors')));
+            box.appendChild(E('p', { 'class': 'cbi-value-description' }, _('OUIs used for the client/WAN side (phones, laptops).')));
+            box.appendChild(vendorCheckboxes('client', st.client_all, st.client_vendors));
+        } else {
+            box.appendChild(E('h4', { 'style': 'margin-bottom:.2em;' }, _('Vendor to mimic')));
+            box.appendChild(E('p', { 'class': 'cbi-value-description' },
+                _('The whole device will look like one of these brands. Leave all checked to pick a brand at random each time; check just one (e.g. tp-link) to always look like that vendor.')));
+            box.appendChild(vendorCheckboxes('ap', st.ap_all, st.ap_vendors));
+        }
+
+        // 4) preview + apply
+        box.appendChild(E('hr', { 'style': 'border:none;border-top:1px solid rgba(128,128,128,.25);margin:.7em 0;' }));
+        var previewOut = E('pre', { 'style': 'margin:.5em 0;' }, '');
+        box.appendChild(E('div', { 'class': 'control-group' }, [
+            E('button', { 'class': 'btn cbi-button', 'click': function() {
+                callBlueMerle('mac-preview').then(function(t) { previewOut.textContent = t; });
+            } }, _('Preview example MACs')),
+            ' ',
+            E('button', { 'class': 'btn cbi-button-positive', 'disabled': isReadonlyView, 'click': function() {
+                callBlueMerle('mac-apply').then(function() {
+                    ui.addNotification(null, E('p', _('MAC mimicry applied. Reload Wi-Fi / restart the network for it to take effect.')));
+                });
+            } }, _('Apply now'))
+        ]));
+        box.appendChild(E('p', { 'class': 'cbi-value-description' },
+            _('Preview only shows examples and changes nothing. Apply writes the new MACs; reload Wi-Fi / restart the network for them to take effect. They are also re-applied on every boot while enabled.')));
+        box.appendChild(previewOut);
+    }).catch(function(err) {
+        container.innerHTML = '';
+        container.appendChild(E('p', { 'class': 'error' }, _('Failed to load MAC settings: ') + err));
+    });
+}
+
+
 return view.extend({
 	load: function() {
 	},
@@ -351,6 +489,10 @@ return view.extend({
 
         const imeiInputID = 'imei-input';
         const imsiInputID = 'imsi-input';
+
+		var macContainer = E('div', { 'id': 'mac-section' }, [
+			E('p', { 'class': 'spinning' }, _('Loading MAC settings…'))
+		]);
 
 		var view = E([], [
 			E('style', { 'type': 'text/css' }, [ css ]),
@@ -383,7 +525,10 @@ return view.extend({
 					//, E('button', { 'class': 'btn cbi-button-action', 'click': handleUpload, 'disabled': isReadonlyView }, [ _('IMEI change…') ]), ' '
 					//, E('button', { 'class': 'btn cbi-button-neutral', 'click': handleConfig }, [ _('Shred config…') ])
 				])
-			])
+			]),
+
+			E('h3', {}, _('MAC / BSSID privacy')),
+			macContainer
 
 		]);
 
@@ -410,6 +555,8 @@ return view.extend({
 		        e.value = "No IMSI found";
 		    }
 		)
+
+		populateMacSection(macContainer);
 
 		return view;
 	},


### PR DESCRIPTION
Supersedes #74. This builds directly on @pasterbele's vendor-OUI approach there —
credit to them for the original idea and first implementation. It reworks that
into an opt-in feature with the disable flag the maintainers asked for on #74,
makes the OUIs coherent across the interfaces, adds a LuCI toggle and vendor
picker, and is tested on hardware.

blue-merle already randomizes the BSSID and client MAC, but as a purely random
locally-administered address — which still stands out, and the stock hardware
OUI (GL Technologies) identifies the device. This instead draws a real vendor
OUI so the device blends in with ordinary consumer hardware. Off by default; no
behaviour change unless enabled.

## What it does

- `blue-merle.mac.mimic` (default 0): master switch.
- Draws a real vendor OUI from `/etc/blue-merle/oui-vendors` — a plain,
  user-editable table — and appends random bytes.
- Two modes:
  - **coherent** (default): the whole device (both radios + WAN) shares one
    vendor OUI with sequential MACs, the way real single-vendor hardware lays out
    its interfaces. On the test unit the factory MACs are eth0 ..:63, wlan0 ..:64,
    wlan1 ..:65 — coherent mode reproduces that pattern.
  - **split**: router (BSSID) and client roles get independent vendor OUIs. Only
    appropriate for a pure Wi-Fi client that does not also broadcast a hotspot.
- `auto_disable_native`: defers to the GL firmware's own MAC randomization on
  versions that ship it — the feature flag #74 was asked to add — so it doesn't
  randomize twice. Detected at runtime, not from a firmware-version assumption.
- A section on the existing LuCI page: enable, mode, vendor pickers, a preview
  button (shows example MACs, changes nothing) and apply.

## Why coherent is the default

Real single-vendor hardware numbers its interfaces from one OUI with a sequential
NIC portion — confirmed on the test device (eth0/wlan0/wlan1 = ..:63/64/65) and on
other integrated boards (a Raspberry Pi's eth/wifi/bt sit adjacent under one OUI).
Coherent mode reproduces that, so the device reads as one integrated unit.
Randomizing each interface independently instead scatters several vendor OUIs
across one box, which is less like real hardware. Mixed-vendor OUIs are not a hard
tell on their own — laptops and repeaters legitimately mix vendors — so this is
about looking like coherent hardware, not about evading a specific detector. Split
stays available for the pure-client case.

## OUI table

The shipped OUIs are public IEEE assignments, validated against the IEEE
registry. The table is a plain file users can edit, which also covers the request
in #45 to choose or supply vendor OUIs.

## Limitations

This changes the MAC and BSSID only. It does not make the rest of the radio's
output match the vendor it borrows an OUI from. The advertised 802.11
capabilities (HT/VHT/HE, supported rates), the order and contents of the beacon
information elements, and the presence or absence of vendor-specific and WPS
elements are produced by the Wi-Fi chipset, its driver and hostapd — not by the
MAC — so they are unchanged. On the GL-E750 the device still fingerprints as an
OpenWrt / ath9k (Atheros QCA9533) AP: the beacon's HT capability layout reveals
the real chipset generation whatever OUI the BSSID carries, and since the QCA9533
is a 2.4 GHz 802.11n part, an OUI borrowed from a Wi-Fi 6 vendor is contradicted
by the radio itself.

So this helps against observers that key on the OUI — Wi-Fi geolocation
databases, captive portals, MAC filtering, casual scans — where the stock
GL.iNet OUI would otherwise flag the device. It does not help against Wi-Fi
fingerprinting that profiles capabilities or IE layout; no MAC change can, since
that information comes from the chipset and firmware.

## Tested

GL-E750 (Mudi v2) on GL.iNet firmware 4.3.26 (OpenWrt 22.03.4 base, ath79/nand),
Atheros QCA9533 / ath9k. Enable, mode switch, vendor selection, preview, apply and
boot persistence all work; `sh -n` passes on the changed scripts and the ACL is
valid JSON. A coherent apply was verified to write one OUI with sequential MACs
across all four interface values (wifi0/wifi1/wan/clone).

Closes #45 — the LuCI vendor picker plus the user-editable OUI table are the
"select a vendor / supply your own OUIs" request raised there.
