### PR TITLE
Drop the redundant shred from volatile-client-macs (#73)

### DIFF
--- a/files/etc/init.d/volatile-client-macs
+++ b/files/etc/init.d/volatile-client-macs
@@ -1,30 +1,56 @@
 #!/bin/sh /etc/rc.common
-
-# MAC addresses of connected clients are stored in a sqlite database.
-# Having the database seems to be necessary for the device to be working properly.
-# We intent to have the device store the database in RAM rather than on flash.
-# We replace the directory with a memory-backed tmpfs which is as volatile as we can make it.
-
-# We want to run ahead of "gl-tertf" which, currently, has a prioprity of 60.
-# We also want to run ahead of "gl_clients" which has 99.
-START=9
+# Keep the connected-client MAC database in RAM, never on flash.
+#
+# gl-tertf / gl_clients record the MAC addresses of connected clients in a sqlite
+# database at /etc/oui-tertf/client.db, on the UBIFS overlay — a persistent log of
+# which devices attached to the router. The previous version shred+rm'd that file
+# on every start and stop. That hammers the NAND (see #73) and, because UBIFS is
+# log-structured, still cannot truly erase the old blocks: an in-place overwrite
+# just allocates a new block and leaves the previous content recoverable.
+#
+# Instead we mount a small tmpfs over /etc/oui-tertf, so the database lives only in
+# RAM: nothing about connected clients is written to flash and the log is gone on
+# reboot. The current database is copied in once so gl-tertf keeps working; the
+# on-flash copy is removed a single time (one unlink — shred buys nothing on UBIFS,
+# same reasoning as the eSIM path).
+#
+# /etc/config/fstab was proposed in #73, but it does not load at boot on the
+# GL-E750 (the GL firmware does not process it there — reported on 4.3.26 and
+# 4.8.3), so an init script is used.
+#
+# Run ahead of gl-tertf (priority 60) and gl_clients (99).
+START=09
 STOP=99
 
-start() {
-    tmpdir="$(mktemp -d)"
-    # We mount a tmpfs so that the client database will be stored in memory only
-    mount -t tmpfs / "$tmpdir"
-    cp -a /etc/oui-tertf/client.db "$tmpdir"
-    shred --force --remove  /etc/oui-tertf/client.db ||  rm -f /etc/oui-tertf/client.db
-    # If this script runs multiple times, we accumulate mounts; we try to avoid having mounts over mounts, so we unmount any existing tmpfs
-    umount -t tmpfs -l /etc/oui-tertf
+DIR=/etc/oui-tertf
+DB=$DIR/client.db
 
-    mount -t tmpfs / /etc/oui-tertf
-    cp -a "$tmpdir/client.db" /etc/oui-tertf/client.db
-    umount -t tmpfs -l "$tmpdir"
+_mounted() { mount 2>/dev/null | grep -q " on $DIR type tmpfs"; }
+
+start() {
+	_mounted && return 0
+
+	# Preserve the current DB in RAM (/tmp is tmpfs) so gl-tertf keeps working.
+	tmp=$(mktemp)
+	[ -f "$DB" ] && cp -a "$DB" "$tmp" 2>/dev/null
+
+	# One-time removal of the on-flash copy (single unlink, not a per-boot shred).
+	rm -f "$DB" 2>/dev/null
+
+	if ! mount -t tmpfs -o mode=0755,size=1M tmpfs "$DIR"; then
+		logger -p err -t volatile-client-macs "tmpfs mount FAILED — leaving DB on flash"
+		[ -f "$tmp" ] && cp -a "$tmp" "$DB"
+		rm -f "$tmp"
+		return 1
+	fi
+
+	[ -f "$tmp" ] && cp -a "$tmp" "$DB"
+	rm -f "$tmp"
+	logger -p notice -t volatile-client-macs "tmpfs mounted over $DIR (client MACs RAM-only)"
 }
+
+boot() { start "$@"; }
 
 stop() {
-	shred /etc/oui-tertf/client.db ||  rm -f /etc/oui-tertf/client.db
+	umount "$DIR" 2>/dev/null
 }
-

--- a/files/etc/init.d/volatile-client-macs
+++ b/files/etc/init.d/volatile-client-macs
@@ -1,24 +1,12 @@
 #!/bin/sh /etc/rc.common
-# Keep the connected-client MAC database in RAM, never on flash.
-#
-# gl-tertf / gl_clients record the MAC addresses of connected clients in a sqlite
-# database at /etc/oui-tertf/client.db, on the UBIFS overlay — a persistent log of
-# which devices attached to the router. The previous version shred+rm'd that file
-# on every start and stop. That hammers the NAND (see #73) and, because UBIFS is
-# log-structured, still cannot truly erase the old blocks: an in-place overwrite
-# just allocates a new block and leaves the previous content recoverable.
-#
-# Instead we mount a small tmpfs over /etc/oui-tertf, so the database lives only in
-# RAM: nothing about connected clients is written to flash and the log is gone on
-# reboot. The current database is copied in once so gl-tertf keeps working; the
-# on-flash copy is removed a single time (one unlink — shred buys nothing on UBIFS,
-# same reasoning as the eSIM path).
-#
-# /etc/config/fstab was proposed in #73, but it does not load at boot on the
-# GL-E750 (the GL firmware does not process it there — reported on 4.3.26 and
-# 4.8.3), so an init script is used.
-#
-# Run ahead of gl-tertf (priority 60) and gl_clients (99).
+
+# MAC addresses of connected clients are stored in a sqlite database.
+# Having the database seems to be necessary for the device to be working properly.
+# We intent to have the device store the database in RAM rather than on flash.
+# We replace the directory with a memory-backed tmpfs which is as volatile as we can make it.
+
+# We want to run ahead of "gl-tertf" which, currently, has a prioprity of 60.
+# We also want to run ahead of "gl_clients" which has 99.
 START=09
 STOP=99
 


### PR DESCRIPTION
`volatile-client-macs` already mounts a tmpfs over /etc/oui-tertf, so the
connected-client MAC database is already RAM-backed. But it also `shred`s the
on-flash copy on every start and stop. As raised in #73, that wears the NAND —
and on UBIFS it achieves nothing anyway: shred overwrites in place, but a
log-structured filesystem just allocates a new block and leaves the old one
recoverable.

This drops the shred. The tmpfs mount is kept (same RAM-only behaviour); the
on-flash copy is removed once with a plain `rm` at first setup instead of a
per-boot shred; and the mount is made idempotent with a 1M size cap (as suggested
on #73).

`/etc/config/fstab` was proposed on #73, but testers reported it does not load at
boot on the GL-E750 (4.3.26 and 4.8.3), so the init-script approach is kept —
just without the per-boot shred.

## What changes

- `start`/`stop` no longer call `shred` (pointless on UBIFS, and it wears the NAND).
- The on-flash copy is removed once with a single `rm` instead of a per-boot shred.
- The mount is idempotent (a second `start` doesn't stack) and size-capped at 1M.

## Tested

GL-E750 (Mudi v2) on GL.iNet firmware 4.3.26:
- `start` mounts the tmpfs over /etc/oui-tertf (size=1M) and preserves client.db;
  the mount is idempotent.
- Across a real reboot the service auto-mounts the tmpfs at boot (before gl-tertf),
  and gl-tertf keeps tracking clients into it — a connected phone's MAC appears in
  the RAM-backed client.db.
- Data written to the mount is gone after stop (verified with a marker file).
- `sh -n` passes.

## Existing residue

This prevents future writes; it does not erase what is already on flash. A device
that ran an earlier version still has the old client.db content on the UBIFS
overlay, and UBIFS — being log-structured with wear-levelling — can't reliably
erase it in place: neither the old shred nor a plain rm removes the underlying
blocks, which stay recoverable until they are physically erased. A
settings-preserving flash doesn't remove it either. For a forensically clean
device, use a factory reset / `sysupgrade -n` / a full reflash that reformats the
overlay (or erase the overlay partition) before installing, after which nothing
sensitive is written to flash.

## Notes

Single-file change (files/etc/init.d/volatile-client-macs), independent of #89 and
#90 — it doesn't touch any file they change.

Closes #73
